### PR TITLE
Add backticks around *args in docstring.

### DIFF
--- a/yamlize/maps.py
+++ b/yamlize/maps.py
@@ -53,8 +53,8 @@ class __MapBase(Object, metaclass=MapType):
         """
         Explicit implementation of __new__ to assign __data as an attribute.
 
-        :param *args: sequence of key/value pairs.
-        :param **kwargs: kwargs for input to OrderedDict.
+        :param ``*args``: sequence of key/value pairs.
+        :param ``**kwargs``: kwargs for input to OrderedDict.
         """
         self = Object.__new__(cls)
         self.__data = OrderedDict()
@@ -64,8 +64,8 @@ class __MapBase(Object, metaclass=MapType):
         """
         Initialize a Map.
 
-        :param *args: sequence of key/value pairs.
-        :param **kwargs: kwargs for input to OrderedDict.
+        :param ``*args``: sequence of key/value pairs.
+        :param ``**kwargs``: kwargs for input to OrderedDict.
         """
         Object.__init__(self)
         self.__data = OrderedDict(*args, **kwargs)


### PR DESCRIPTION
Having parameter docs named *args and **kwargs in a docstring
was causing downstream errors in sphinx where sphinx thought it was
going to be an italic block with a following asterisk or two.

docutils recommends that things like this should be liberals:

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules

Fixes https://github.com/terrapower/armi/issues/481