### PR TITLE
Support Python 3.7-3.9 more officially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 
 install: pip install tox-travis
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.7.0',
+    version='0.7.1',
 
     description='yamlize, a package for Python object serialization and data validation.',
     long_description='see https://github.com/SimplyKnownAsG/yamlize/blob/master/README.rst',
@@ -40,6 +40,9 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 
 [testenv]
 basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 deps =
     pycodestyle
     pytest


### PR DESCRIPTION
Up until now, this project has only officially supported up to Python 3.6 on PyPI, because that is explicitly what is stated in the `setup.py`.  However, I have some evidence:

* In this repo, TOX has already been running unit tests for 3.7 and 3.8.
* In this repo, Travis CI has already been testing Python 3.7 and 3.8.
* The [ARMI](https://github.com/terrapower/armi/) team has been using Yamlize for Python 3.7 and 3.9 for years.
* Yamlize works fine on my laptop (Ubuntu 20.04) in Python 3.7 and 3.9.

**NOTE**: I had to rev the version number of `yamlize` for this to take effect. Essentially, PyPI does not like it if you try to upload a version of a package that already exists. So, in order to get official support for Python 3.7-3.9, `yamlize` will have to be uploaded to PyPI again with a (very slightly) increased version number.